### PR TITLE
Fix bug when filling gaps for complete tsibble

### DIFF
--- a/R/gaps.R
+++ b/R/gaps.R
@@ -113,14 +113,14 @@ fill_gaps.tbl_ts <- function(.data, ..., .full = FALSE) {
       anti_join(.data, by = c(key_vars(.data), idx_chr))
     by_name <- intersect(names(filled_data), names(replaced_df))
 
-    if (NROW(replaced_df) > NROW(filled_data)) {
+    if (is_empty(by_name)) { # by value
+      filled_data <- filled_data %>%
+        mutate(!!! replaced_df)
+    } else if (NROW(replaced_df) > NROW(filled_data)) {
       abort(sprintf(
         "Replacement has length %s, not 1 or %s.", 
         NROW(replaced_df), NROW(filled_data)
       ))
-    } else if (is_empty(by_name)) { # by value
-      filled_data <- filled_data %>% 
-        mutate(!!! replaced_df)
     } else { # by function
       filled_data <- filled_data %>% 
         left_join(replaced_df, by = by_name)

--- a/tests/testthat/test-fill-na.R
+++ b/tests/testthat/test-fill-na.R
@@ -26,7 +26,7 @@ test_that("an irregular tbl_ts", {
 
 test_that("a tbl_ts without implicit missing values", {
   tsbl <- as_tsibble(dat_x, index = date)
-  expect_identical(fill_gaps(tsbl), tsbl)
+  expect_identical(fill_gaps(tsbl, value = 0), tsbl)
   ref_tbl <- tibble(.from = NA, .to = NA, .n = 0L)
   expect_identical(count_gaps(tsbl), ref_tbl)
 })


### PR DESCRIPTION
Previous test were in the form `fill_gaps(tsbl)`, without other arguments.
With a replacement value however, the code crashed.
The proposed solution is to check first if the intersection between
`replaced_df` and `filled_data` is empty, and only then look if number of
rows are matching.