### PR TITLE
fixed guess_frequency.yearweek

### DIFF
--- a/R/tsibble2ts.R
+++ b/R/tsibble2ts.R
@@ -143,7 +143,7 @@ guess_frequency.numeric <- function(x) {
 
 #' @export
 guess_frequency.yearweek <- function(x) {
-  52 / pull_interval(x)$month
+  52 / pull_interval(x)$week
 }
 
 #' @export


### PR DESCRIPTION
Hi.

`guess_frequency()` doesn't work properly with `yearweek`.

``` r
library(tsibble, warn.conflicts = FALSE)

guess_frequency(
  yearweek(seq(
    as.Date("2017-01-01"), as.Date("2017-01-31"),
    by = '1 week'
)))
#> [1] Inf
```
<sup>Created on 2019-02-09 by the [reprex package](https://reprex.tidyverse.org) (v0.2.1)</sup>

This commit fixes the bug.