### PR TITLE
Fix interval_pull.POSIXt giving invalid intervals for >daily intervals

### DIFF
--- a/R/interval.R
+++ b/R/interval.R
@@ -34,8 +34,10 @@ interval_pull.POSIXt <- function(x) {
   nhms <- gcd_interval(dttm)
   period <- split_period(nhms)
   init_interval(
-    hour = period$hour, 
-    minute = period$minute, 
+    year = period$year,
+    day = period$day,
+    hour = period$hour,
+    minute = period$minute,
     second = period$second %/% 1,
     millisecond = period$second %% 1 %/% 1e-3,
     microsecond = period$second %% 1 %/% 1e-6 %% 1e+3


### PR DESCRIPTION
Even though it is better to store dates using `date` objects, it is still reasonable to have `datetime` objects that are separated by days. The correct interval is already computed by `split_period`, so why not use it? If you want to encourage users to have more appropriate classes, then a message is probably more appropriate than giving a bad interval.

``` r
# Before
tsibble::interval_pull(as.POSIXct(Sys.Date() + 1:10))
#> ?
```

<sup>Created on 2019-05-15 by the [reprex package](https://reprex.tidyverse.org) (v0.2.1)</sup>

``` r
# After
tsibble::interval_pull(as.POSIXct(Sys.Date() + 1:10))
#> 1D
```

<sup>Created on 2019-05-15 by the [reprex package](https://reprex.tidyverse.org) (v0.2.1)</sup>