### PR TITLE
Performance improvements for build_tsibble

### DIFF
--- a/R/as-tsibble.R
+++ b/R/as-tsibble.R
@@ -283,7 +283,7 @@ build_tsibble_meta <- function(
 ) {
   stopifnot(is_string(index) && is_string(index2))
   stopifnot(!is_null(ordered))
-  stopifnot(tibble::is_tibble(x))
+  stopifnot(is.data.frame(x))
   tbl <- x
   attr(index, "ordered") <- ordered
 

--- a/R/as-tsibble.R
+++ b/R/as-tsibble.R
@@ -283,7 +283,8 @@ build_tsibble_meta <- function(
 ) {
   stopifnot(is_string(index) && is_string(index2))
   stopifnot(!is_null(ordered))
-  tbl <- as_tibble(x)
+  stopifnot(tibble::is_tibble(x))
+  tbl <- x
   attr(index, "ordered") <- ordered
 
   is_interval <- inherits(interval, "interval")

--- a/R/deprecated.R
+++ b/R/deprecated.R
@@ -68,7 +68,7 @@ id <- function(...) {
 
 use_id <- function(x, key) {
   key_quo <- enquo(key)
-  if(quo_is_null(key_quo)){
+  if (quo_is_null(key_quo)) {
     return(character())
   }
   if (quo_is_call(key_quo)) {

--- a/R/deprecated.R
+++ b/R/deprecated.R
@@ -68,6 +68,9 @@ id <- function(...) {
 
 use_id <- function(x, key) {
   key_quo <- enquo(key)
+  if(quo_is_null(key_quo)){
+    return(character())
+  }
   if (quo_is_call(key_quo)) {
     call_fn <- call_name(key_quo)
     if (call_fn == "id") {


### PR DESCRIPTION
Some expensive operations can be simplified. This is especially important in speeding up fable as simpler tsibble structures are being created for each key in the data. Adding shortcuts for when `key = NULL`, and removing an unnecessary `as_tibble` speeds things up a bit.

It would also be nice to have `validate=FALSE` do even less checking, as in many cases you are starting from a valid tsibble, and do not need

## Before
``` r
library(tsibble)
bench::mark(
  fablelite:::nest_keys(tourism)
)
#> Warning: Some expressions had a GC in every iteration; so filtering is
#> disabled.
#> # A tibble: 1 x 10
#>   expression   min  mean median   max `itr/sec` mem_alloc  n_gc n_itr
#>   <chr>      <bch> <bch> <bch:> <bch>     <dbl> <bch:byt> <dbl> <int>
#> 1 fablelite… 1.11s 1.11s  1.11s 1.11s     0.902        0B    20     1
#> # … with 1 more variable: total_time <bch:tm>
```

<sup>Created on 2019-06-05 by the [reprex package](https://reprex.tidyverse.org) (v0.2.1)</sup>

## After
``` r
library(tsibble)
bench::mark(
  fablelite:::nest_keys(tourism)
)
#> Warning: Some expressions had a GC in every iteration; so filtering is
#> disabled.
#> # A tibble: 1 x 10
#>   expression   min  mean median   max `itr/sec` mem_alloc  n_gc n_itr
#>   <chr>      <bch> <bch> <bch:> <bch>     <dbl> <bch:byt> <dbl> <int>
#> 1 fablelite… 807ms 807ms  807ms 807ms      1.24        0B    14     1
#> # … with 1 more variable: total_time <bch:tm>
```

<sup>Created on 2019-06-05 by the [reprex package](https://reprex.tidyverse.org) (v0.2.1)</sup>