### PR TITLE
Fixed yearquarter.character not flooring the underlying date

### DIFF
--- a/R/period.R
+++ b/R/period.R
@@ -419,7 +419,7 @@ yearquarter.character <- function(x) {
     if (any(qtr > 4)) {
       abort("Quarters can't be greater than 4.")
     }
-    as_yearquarter(lubridate::make_date(yr, qtr * 3))
+    as_yearquarter(lubridate::make_date(yr, qtr * 3 - 2))
   } else {
     anytime::assertDate(x)
     as_yearquarter(anytime::anydate(x))


### PR DESCRIPTION
## Before

```r
library(tsibble)
library(dplyr)
#> 
#> Attaching package: 'dplyr'
#> The following object is masked from 'package:tsibble':
#> 
#>     id
#> The following objects are masked from 'package:stats':
#> 
#>     filter, lag
#> The following objects are masked from 'package:base':
#> 
#>     intersect, setdiff, setequal, union
tourism %>% filter(Quarter < yearquarter("1998 Q1"))
#> # A tsibble: 304 x 5 [?]
#> # Key:       Region, State, Purpose [304]
#>    Quarter Region         State              Purpose   Trips
#>      <qtr> <chr>          <chr>              <chr>     <dbl>
#>  1 1998 Q1 Adelaide       South Australia    Business 135.  
#>  2 1998 Q1 Adelaide       South Australia    Holiday  224.  
#>  3 1998 Q1 Adelaide       South Australia    Other     58.4 
#>  4 1998 Q1 Adelaide       South Australia    Visiting 242.  
#>  5 1998 Q1 Adelaide Hills South Australia    Business   0   
#>  6 1998 Q1 Adelaide Hills South Australia    Holiday    6.81
#>  7 1998 Q1 Adelaide Hills South Australia    Other      0   
#>  8 1998 Q1 Adelaide Hills South Australia    Visiting   2.99
#>  9 1998 Q1 Alice Springs  Northern Territory Business   7.54
#> 10 1998 Q1 Alice Springs  Northern Territory Holiday    8.15
#> # … with 294 more rows
```

## After
``` r
library(tsibble)
library(dplyr)
#> 
#> Attaching package: 'dplyr'
#> The following object is masked from 'package:tsibble':
#> 
#>     id
#> The following objects are masked from 'package:stats':
#> 
#>     filter, lag
#> The following objects are masked from 'package:base':
#> 
#>     intersect, setdiff, setequal, union
tourism %>% filter(Quarter < yearquarter("1998 Q1"))
#> # A tsibble: 0 x 5 [?]
#> # Key:       Region, State, Purpose [0]
#> # … with 5 variables: Quarter <qtr>, Region <chr>, State <chr>,
#> #   Purpose <chr>, Trips <dbl>
```

<sup>Created on 2019-06-16 by the [reprex package](https://reprex.tidyverse.org) (v0.2.1)</sup>