### PR TITLE
Improve performance of assert_key_data

### DIFF
--- a/R/as-tsibble.R
+++ b/R/as-tsibble.R
@@ -559,11 +559,12 @@ remove_tsibble_attrs <- function(x) {
 }
 
 assert_key_data <- function(x) {
+  nc <- length(x)
   if (is_false(
     is.data.frame(x) &&
-      NCOL(x) > 0 &&
-      is.list(x[[NCOL(x)]]) &&
-      tail(names(x), 1L) == ".rows"
+    nc > 0 &&
+    is.list(x[[nc]]) &&
+    names(x)[[nc]] == ".rows"
   )) {
     abort("The `key` attribute must be a data frame with its last column called `.rows`.")
   }


### PR DESCRIPTION
``` r
library(tsibble)
library(rlang)
assert_key_data <- tsibble:::assert_key_data

assert_key_data_new <- function(x) {
  nc <- length(x)
  if (is_false(
    is.data.frame(x) &&
    nc > 0 &&
    is.list(x[[nc]]) &&
    names(x)[[nc]] == ".rows"
  )) {
    abort("The `key` attribute must be a data frame with its last column called `.rows`.")
  }
}


kd <- key_data(pedestrian)

bench::mark(
  assert_key_data(kd),
  assert_key_data_new(kd)
)
#> # A tibble: 2 x 6
#>   expression                   min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>              <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 assert_key_data(kd)      37.94µs  40.41µs    23908.        0B     16.7
#> 2 assert_key_data_new(kd)   6.61µs   7.15µs   106009.        0B     10.6
```

<sup>Created on 2019-08-14 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>