### PR TITLE
Improve performance by not resetting row.names in new_tsibble

### DIFF
--- a/R/as-tsibble.R
+++ b/R/as-tsibble.R
@@ -349,8 +349,7 @@ build_tsibble_meta <- function(x, key_data = NULL, index, index2,
 new_tsibble <- function(x, ..., class = NULL) {
   not_tsibble(x)
   x <- new_tibble(x, ..., nrow = NROW(x), class = "tbl_ts")
-  assert_key_data(x %@% key)
-  attr(x, "row.names") <- .set_row_names(NROW(x))
+  assert_key_data(attr(x, "key"))
   class(x) <- c(class, class(x))
   x
 }


### PR DESCRIPTION
As discussed in #139. I've also removed usage of infix `%@%` as `new_tsibble` should be performant.

``` r
library(tsibble)

not_tsibble <- tsibble:::not_tsibble
assert_key_data <- tsibble:::assert_key_data
new_tibble <- tibble:::new_tibble
new_tsibble_new <- function(x, ..., class = NULL) {
  not_tsibble(x)
  x <- new_tibble(x, ..., nrow = NROW(x), class = "tbl_ts")
  assert_key_data(attr(x, "key"))
  class(x) <- c(class, class(x))
  x
}

bench::mark(
  new_tsibble(pedestrian, class = "new_ts"),
  new_tsibble_new(pedestrian, class = "new_ts")
)
#> # A tibble: 2 x 6
#>   expression                                       min median `itr/sec`
#>   <bch:expr>                                    <bch:> <bch:>     <dbl>
#> 1 new_tsibble(pedestrian, class = "new_ts")       43µs 47.2µs    18893.
#> 2 new_tsibble_new(pedestrian, class = "new_ts") 26.4µs 29.4µs    29392.
#> # … with 2 more variables: mem_alloc <bch:byt>, `gc/sec` <dbl>
```

<sup>Created on 2019-08-14 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>