### PR TITLE
Improve performance of time_unit

### DIFF
--- a/R/interval.R
+++ b/R/interval.R
@@ -257,7 +257,7 @@ time_unit <- function(x) {
   x[["millisecond"]] <- x[["millisecond"]] * 1e-3
   x[["minute"]] <- x[["minute"]] * 60
   x[["hour"]] <- x[["hour"]] * 3600
-  reduce(x, `+`)
+  sum(as.numeric(x))
 }
 
 # from ts time to dates


### PR DESCRIPTION
``` r
library(tsibble)
library(rlang)
x <- interval(pedestrian)
time_unit_new <- function(x) {
  if (is_false(inherits(x, "interval"))) {
    abort("Must be class interval.")
  }
  x[["microsecond"]] <- x[["microsecond"]] * 1e-6
  x[["millisecond"]] <- x[["millisecond"]] * 1e-3
  x[["minute"]] <- x[["minute"]] * 60
  x[["hour"]] <- x[["hour"]] * 3600
  sum(as.numeric(x))
}

bench::mark(
  time_unit(x),
  time_unit_new(x)
)
#> # A tibble: 2 x 6
#>   expression            min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>       <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 time_unit(x)      270.3µs  303.1µs     3076.        0B     14.6
#> 2 time_unit_new(x)   21.4µs   24.7µs    35106.        0B     21.1
```

<sup>Created on 2019-08-14 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>