### PR TITLE
implement relative differences

### DIFF
--- a/R/time-wise.R
+++ b/R/time-wise.R
@@ -129,7 +129,6 @@ tdifference <- function(x, lag = 1, differences = 1, default = NA, order_by) {
 #'     lag_income = keyed_lag(income),
 #'     lead_income = keyed_lead(income),
 #'     diff_income = keyed_difference(income),
-#'     rel_diff_income = 
 #'   )
 #'
 #' # take care of key and gaps


### PR DESCRIPTION
Implemented the ability to calculate relative differences with the difference function. Code from base R's diff function replaces the call to diff, in order to allow for each iterative difference to be a relative difference. Otherwise, the diff_impl function executes the same code as the diff function. The test for appropriate vector length is implemented in the difference function, as is a test for 0 in x, which invalidates a relative difference. A warning for differences above 1 is also included, as it might not be intuitive that a second relative difference is the relative difference in a relative difference. One use of relative = TRUE is added to the examples, and the parameter is defined for the difference function.
Changed non-1L defaults for lag and differences parameters to 1L defaults.
Added relative parameter to keyed_difference.