### PR TITLE
Retain tsibble class in `[.tbl_ts` for logical i inputs

### DIFF
--- a/R/subset.R
+++ b/R/subset.R
@@ -25,7 +25,7 @@
   new_key <- cn[cn %in% key_vars(x)]
 
   if (!missing(i)) {
-    if (vec_duplicate_any(i) > 0) return(as_tibble(res))
+    if (vec_duplicate_any(i) > 0 && is.numeric(i)) return(as_tibble(res))
   }
 
   not_tsibble <- !(index_var(x) %in% cn) || vec_size(res) > vec_size(x)


### PR DESCRIPTION
https://github.com/tidyverts/tsibble/blob/7a13449e39d4e2b71f416cc5fdcb3eb57c174eec/R/subset.R#L27-L29

Presumably this check is intended to check for repeated rows in the resulting table, which would give an invalid tsibble. When `i` is provided as a logical vector, it is not possible to repeat rows via indexing.

Resolves https://github.com/tidyverts/fable/issues/218