### PR TITLE
Fix modular arith for sub-second interval_pull

### DIFF
--- a/R/interval.R
+++ b/R/interval.R
@@ -40,8 +40,8 @@ interval_pull.POSIXt <- function(x) {
     hour = period$hour,
     minute = period$minute,
     second = period$second %/% 1,
-    millisecond = period$second %% 1 %/% 1e-3,
-    microsecond = period$second %% 1 %/% 1e-6 %% 1e+3
+    millisecond = (period$second %% 1 * 1e3) %/% 1,
+    microsecond = (period$second %% 1 * 1e3) %% 1 * 1e3
   )
 }
 


### PR DESCRIPTION
Avoid using non-integer values with `%%` and `%/%`.

> %% and x %/% y can be used for non-integer y, e.g. 1 %/% 0.2, but the results are subject to representation error and so may be platform-dependent. Because the IEC 60559 representation of 0.2 is a binary fraction slightly larger than 0.2, the answer to 1 %/% 0.2 should be 4 but most platforms give 5.

Related: https://github.com/tidyverts/fable/issues/220

---

Before:
``` r
tsibble::interval_pull(Sys.time() + lubridate::milliseconds((1:10)*500))
#> <interval[1]>
#> [1] 499ms
```

<sup>Created on 2020-01-23 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>

After:
``` r
tsibble::interval_pull(Sys.time() + lubridate::milliseconds((1:10)*500))
#> <interval[1]>
#> [1] 500ms
```

<sup>Created on 2020-01-23 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>