### PR TITLE
Fix format.yearquarter() erroring on NA values

### DIFF
--- a/R/yearquarter.R
+++ b/R/yearquarter.R
@@ -282,6 +282,8 @@ format.yearquarter <- function(x, format = "%Y Q%q", ...) {
   x <- as_date(x)
   qtr <- quarter(x)
   qtr_sub <- map_chr(qtr, function(z) gsub("%q", z, x = format))
+  qtr_sub[is.na(qtr_sub)] <- "-" # NA formats cause errors
+
   format.Date(x, format = qtr_sub)
 }
 

--- a/tests/testthat/test-yearquarter.R
+++ b/tests/testthat/test-yearquarter.R
@@ -61,3 +61,7 @@ test_that("vec_c() for yearquarter()", {
   # expect_identical(vec_c(yearquarter(x), dttm), rep(dttm, times = 2))
   expect_identical(vec_c(dates, yearquarter(x)), c(dates, yearquarter(x)))
 })
+
+test_that("format.yearquarter() with NA presence #170", {
+  expect_equal(format(c(yearquarter("1970 Q1"), NA)), c("1970 Q1", NA))
+})


### PR DESCRIPTION
The `format.Date()` function requires that the `format` argument to be non-missing characters.

``` r
library(tsibble)
yq <- vctrs::vec_c(NA, yearquarter("1970 Q1"))
format(yq)
#> Error in if (any(f0 <- format == "")) {: missing value where TRUE/FALSE needed
```

<sup>Created on 2020-03-05 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>