### PR TITLE
Fixes #194

### DIFF
--- a/R/as-tsibble.R
+++ b/R/as-tsibble.R
@@ -213,7 +213,7 @@ as_tsibble.NULL <- function(x, ...) {
 #'   update_tsibble(index = Hour_Since)
 #'
 #' # update key: drop the variable "State" from the key
-#' tourism %>% 
+#' tourism %>%
 #'   update_tsibble(key = c(Purpose, Region))
 update_tsibble <- function(x, key, index, regular = is_regular(x),
                            validate = TRUE, .drop = key_drop_default(x)) {
@@ -302,7 +302,7 @@ build_tsibble <- function(x, key = NULL, key_data = NULL, index, index2 = index,
     abort(sprintf("Column `%s` can't be both index and key.", idx_chr[[1]]))
   }
   # arrange index from past to future for each key value
-  if (vec_size(tbl) == 0 || is_null(ordered)) { # first time to create a tsibble
+  if ((vec_size(tbl) == 0 || is_null(ordered)) && nrow(tbl) > 0) { # first time to create a tsibble
     tbl <- arrange(tbl, !!!syms(key_vars), !!sym(index))
     ordered <- TRUE
   }
@@ -469,7 +469,7 @@ validate_tsibble <- function(data, key, index, key_data = NULL) {
   is_dup <- duplicated_key_index(data, key, index, key_data)
   if (is_dup) {
     abort(c(
-      "A valid tsibble must have distinct rows identified by key and index.", 
+      "A valid tsibble must have distinct rows identified by key and index.",
       i = "Please use `duplicates()` to check the duplicated rows."))
   }
   data

--- a/R/as-tsibble.R
+++ b/R/as-tsibble.R
@@ -301,8 +301,12 @@ build_tsibble <- function(x, key = NULL, key_data = NULL, index, index2 = index,
   if (!is_empty(is_index_in_keys)) {
     abort(sprintf("Column `%s` can't be both index and key.", idx_chr[[1]]))
   }
+  # tibbles with no rows are trivially ordered
+  if (nrow(tbl) == 0) {
+    ordered <- TRUE
+  }
   # arrange index from past to future for each key value
-  if ((vec_size(tbl) == 0 || is_null(ordered)) && nrow(tbl) > 0) { # first time to create a tsibble
+  else if ((vec_size(tbl) == 0 || is_null(ordered))) { # first time to create a tsibble
     tbl <- arrange(tbl, !!!syms(key_vars), !!sym(index))
     ordered <- TRUE
   }

--- a/tests/testthat/test-tsibble.R
+++ b/tests/testthat/test-tsibble.R
@@ -435,3 +435,8 @@ test_that("update_tsibble() for different index and index2", {
     "Date"
   )
 })
+
+test_that("build_tsibble() zero slices of grouped tsibbles don't crash #194", {
+  ped2 <- pedestrian %>% group_by(Sensor)
+  expect_equal(nrow(ped2[0,]), 0L)
+})


### PR DESCRIPTION
So, I think the source of this problem is in `dplyr`, (tidyverse/dplyr#5541), but here is a workaround.  There is no need to order the tsibble if there are no rows, so skip the step that causes the crash.

``` r
library(tsibble)
grped_ped <- pedestrian %>% dplyr::group_by(Sensor)
grped_ped[0, ]
#> # A tsibble: 0 x 5 [?] <Australia/Melbourne>
#> # Key:       Sensor [0]
#> # Groups:    Sensor [?]
#> # ... with 5 variables: Sensor <chr>, Date_Time <dttm>, Date <date>,
#> #   Time <int>, Count <int>
```

<sup>Created on 2020-09-29 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>
