### PR TITLE
fixes missing 'by' in seq.yearmonth()

### DIFF
--- a/R/yearmonth.R
+++ b/R/yearmonth.R
@@ -259,16 +259,23 @@ vec_ptype_abbr.yearmonth <- function(x, ...) {
 #' @export
 seq.yearmonth <- function(from, to, by, length.out = NULL, along.with = NULL,
                           ...) {
-  bad_by(by)
-  by_mth <- paste(by, "month")
   from <- vec_cast(from, new_date())
   if (!is_missing(to)) {
     to <- vec_cast(to, new_date())
   }
-  new_yearmonth(seq_date(
-    from = from, to = to, by = by_mth, length.out = length.out,
-    along.with = along.with, ...
-  ))
+  if (missing(by)) {
+    new_yearmonth(seq_date(
+      from = from, to = to, length.out = length.out,
+      along.with = along.with, ...
+    ))
+  } else {
+    bad_by(by)
+    by_mth <- paste(by, "month")
+    new_yearmonth(seq_date(
+      from = from, to = to, by = by_mth, length.out = length.out,
+      along.with = along.with, ...
+    ))
+  }
 }
 
 bad_by <- function(by) {


### PR DESCRIPTION
Currently if a `yearmonth` column is present in a `tsibble`, using `seq` on it without specifying `by` results in an error
```
Error in bad_by(by) : argument "by" is missing, with no default
```
Due to `seq.yearmonth()` calling `bad_by(by)`.

However, the `by` argument is not required by `seq` generally (as `length.out` could be instead) and nor is it required for `seq.yearmonth` (or `seq.yearquarter`).

There may be a more elegant method of fixing this, but I figure having a potential fix is better than not! I'm happy to reimplement however you like (and do the same for `seq.yearquarter` as necessary).