### PR TITLE
Add support for quarters to `interval_pull`

### DIFF
--- a/R/interval.R
+++ b/R/interval.R
@@ -297,7 +297,8 @@ gcd_interval <- function(x) {
 }
 
 is_quarter.POSIXt <- function(x) {
-  all(diff(lubridate::month(x)) %% 3 == 0)
+  .years <- diff(lubridate::year(x)) < 1
+  all(diff(lubridate::month(x)) %% 3 == 0) && length(.years) > sum(.years)
 }
 
 quarter_multiple.POSIXt <- function(x) {
@@ -329,7 +330,7 @@ setOldClass(c("interval", "vctrs_rcrd", "vctrs_vctr"))
 #' @importMethodsFrom lubridate as.period
 setMethod("as.period", "interval", function(x, ...) {
   period(
-    year = x$year, 
+    year = x$year,
     month = x$quarter * 3 + x$month,
     week = x$week,
     day = x$day,

--- a/R/interval.R
+++ b/R/interval.R
@@ -297,8 +297,7 @@ gcd_interval <- function(x) {
 }
 
 is_quarter.POSIXt <- function(x) {
-  .years <- diff(lubridate::year(x)) < 1
-  all(diff(lubridate::month(x)) %% 3 == 0) && length(.years) > sum(.years)
+  all(diff(lubridate::month(x)) %% 3 == 0) && diff(x) < 365
 }
 
 quarter_multiple.POSIXt <- function(x) {

--- a/R/interval.R
+++ b/R/interval.R
@@ -32,16 +32,25 @@ interval_pull.default <- function(x) {
 #' @export
 # Assume date is regularly spaced
 interval_pull.POSIXt <- function(x) {
-  dttm <- as.double(x)
-  nhms <- gcd_interval(dttm)
-  period <- split_period(nhms)
-  new_interval(
-    hour = period$hour,
-    minute = period$minute,
-    second = period$second %/% 1,
-    millisecond = (period$second %% 1 * 1e3) %/% 1,
-    microsecond = (period$second %% 1 * 1e3) %% 1 * 1e3
-  )
+  if (is_quarter.POSIXt(x)) {
+    new_interval(
+      quarter = quarter_multiple.POSIXt(x)
+    )
+  } else {
+    dttm <- as.double(x)
+    nhms <- gcd_interval(dttm)
+    period <- split_period(nhms)
+    new_interval(
+      year = period$year,
+      month = period$month,
+      day = period$day,
+      hour = period$hour,
+      minute = period$minute,
+      second = period$second %/% 1,
+      millisecond = (period$second %% 1 * 1e3) %/% 1,
+      microsecond = (period$second %% 1 * 1e3) %% 1 * 1e3
+    )
+  }
 }
 
 #' @export
@@ -285,6 +294,14 @@ gcd_interval <- function(x) {
     unique_x <- vec_unique(round(abs(diff(x)), digits = 6))
     gcd_vector(unique_x)
   }
+}
+
+is_quarter.POSIXt <- function(x) {
+  all(diff(lubridate::month(x)) %% 3 == 0)
+}
+
+quarter_multiple.POSIXt <- function(x) {
+  unique(diff(lubridate::month(x)) %% 3 + 1)
 }
 
 gcd <- function(a, b) {

--- a/R/interval.R
+++ b/R/interval.R
@@ -301,7 +301,10 @@ is_quarter.POSIXt <- function(x) {
 }
 
 quarter_multiple.POSIXt <- function(x) {
-  unique(diff(lubridate::month(x)) %% 3 + 1)
+  .x <- diff(lubridate::month(x)) %% 3 + 1
+  .u <- unique(.x)
+  tab <- tabulate(match(.x, .u))
+  .u[tab == max(tab)]
 }
 
 gcd <- function(a, b) {


### PR DESCRIPTION
Combines changes from #236 and adds support for quarters in interval_pull.POSIXt
