### PR TITLE
Corrected typo in examples for index_by

### DIFF
--- a/R/index-by.R
+++ b/R/index-by.R
@@ -67,7 +67,7 @@
 #'   group_by(Region, State) %>%
 #'   summarise(Total = sum(Trips))
 #'
-#' # Rouding to financial year, using a custom function
+#' # Rounding to financial year, using a custom function
 #' financial_year <- function(date) {
 #'   year <- year(date)
 #'   ifelse(quarter(date) <= 2, year, year + 1)


### PR DESCRIPTION
Furthermore, on the pkgdown page this example is not working:
https://tsibble.tidyverts.org/reference/index-by.html#examples

Can reproduce this error message locally if library lubridate is not loaded

tourism %>%
  index_by(Year = ~ financial_year(.)) %>%
  summarise(Total = sum(Trips))
#> Error: Problem with `mutate()` input `Year`.
#> ✖ could not find function "financial_year"
#> ℹ Input `Year` is `f(Quarter)`.