### PR TITLE
dplyr no longer using dplyr°_error class

### DIFF
--- a/tests/testthat/test-gaps.R
+++ b/tests/testthat/test-gaps.R
@@ -163,8 +163,8 @@ test_that("count_gaps(.full = )", {
     .n = 1L
   )
   expect_equal(full_tbl_f, b)
-  expect_error(count_gaps(tsbl, .name = NULL), class = "dplyr_error")
-  expect_error(count_gaps(tsbl, .name = 1:4), class = "dplyr_error")
+  expect_error(count_gaps(tsbl, .name = NULL))
+  expect_error(count_gaps(tsbl, .name = 1:4))
   expect_named(
     count_gaps(tsbl, .name = c("from", "to", "n")),
     c("group", "from", "to", "n")


### PR DESCRIPTION
We're in the process of releasing dplyr 1.0.8, which will stop adding the `dplyr_error` class to errors. Please consider this pull request. 