### PR TITLE
Fix lubridate 'roll' warning #291

### DIFF
--- a/R/filter-index.R
+++ b/R/filter-index.R
@@ -200,7 +200,7 @@ start_window.POSIXct <- function(x, y = NULL, ...) {
     abort_not_chr(y, class = "POSIXct")
     assertTime(y)
     y <- utctime(y, tz = "UTC")
-    force_tz(y, tz(x), roll = TRUE)
+    force_tz(y, tz(x), roll_dst = c("boundary", "post"))
   }
 }
 
@@ -215,7 +215,7 @@ end_window.POSIXct <- function(x, y = NULL, ...) {
     lgl_yrmth <- nchar(y) < 9 & nchar(y) > 4
     lgl_yr <- nchar(y) < 5
     y <- utctime(y, tz = "UTC")
-    y <- force_tz(y, tz(x), roll = TRUE)
+    y <- force_tz(y, tz(x), roll_dst = c("boundary", "post"))
     if (any(lgl_date)) {
       y[lgl_date] <- y[lgl_date] + period(1, "day")
     }


### PR DESCRIPTION
Hi there, 

`tsibble` is giving a warning related to a deprecated argument (`roll`) in the [`lubridate`](https://github.com/tidyverse/lubridate) package. According to the warning, the `roll` argument was deprecated in version `1.8.4`.

It's a simple fix. Please check issue #291 for more details.

I'm using `tsibble` while developing the [`actverse`](https://github.com/giperbio/actverse) package and this warning is becoming really annoying.

BTW, thank you for this great package!