### PR TITLE
Fix key comparison for column selection matching non-syntactical names

### DIFF
--- a/R/subset.R
+++ b/R/subset.R
@@ -51,7 +51,7 @@
   }
 
   new_key <- cn[cn %in% key_vars(x)]
-  maybe_tsibble <- n_keys(x) > 1 && !all(is.element(key(x), new_key))
+  maybe_tsibble <- n_keys(x) > 1 && !all(is.element(key_vars(x), new_key))
 
   # Column subsetting only
   if (is_null(i) && !is_null(j) && maybe_tsibble) return(as_tibble(res))


### PR DESCRIPTION
Resolves #305

``` r
library(tsibble)
#> 
#> Attaching package: 'tsibble'
#> The following objects are masked from 'package:base':
#> 
#>     intersect, setdiff, union
names(tourism)[2] <- "My Region"
tourism[1:5]
#> # A tsibble: 24,320 x 5 [1Q]
#> # Key:       My Region, State, Purpose [304]
#>    Quarter `My Region` State           Purpose  Trips
#>      <qtr> <chr>       <chr>           <chr>    <dbl>
#>  1 1998 Q1 Adelaide    South Australia Business  135.
#>  2 1998 Q2 Adelaide    South Australia Business  110.
#>  3 1998 Q3 Adelaide    South Australia Business  166.
#>  4 1998 Q4 Adelaide    South Australia Business  127.
#>  5 1999 Q1 Adelaide    South Australia Business  137.
#>  6 1999 Q2 Adelaide    South Australia Business  200.
#>  7 1999 Q3 Adelaide    South Australia Business  169.
#>  8 1999 Q4 Adelaide    South Australia Business  134.
#>  9 2000 Q1 Adelaide    South Australia Business  154.
#> 10 2000 Q2 Adelaide    South Australia Business  169.
#> # i 24,310 more rows
tsibble::tourism[1:5]
#> # A tsibble: 24,320 x 5 [1Q]
#> # Key:       Region, State, Purpose [304]
#>    Quarter Region   State           Purpose  Trips
#>      <qtr> <chr>    <chr>           <chr>    <dbl>
#>  1 1998 Q1 Adelaide South Australia Business  135.
#>  2 1998 Q2 Adelaide South Australia Business  110.
#>  3 1998 Q3 Adelaide South Australia Business  166.
#>  4 1998 Q4 Adelaide South Australia Business  127.
#>  5 1999 Q1 Adelaide South Australia Business  137.
#>  6 1999 Q2 Adelaide South Australia Business  200.
#>  7 1999 Q3 Adelaide South Australia Business  169.
#>  8 1999 Q4 Adelaide South Australia Business  134.
#>  9 2000 Q1 Adelaide South Australia Business  154.
#> 10 2000 Q2 Adelaide South Australia Business  169.
#> # i 24,310 more rows
```

<sup>Created on 2024-03-02 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>