### PR TITLE
Fix `difference()` giving extra NA values for short vectors

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,5 @@
+* Fix `difference()` giving extra NA values when the time series is shorter than the lag length. (#310, @mitchelloharawild)
+
 # tsibble 1.1.4
 
 * Fixed `vec_ptype2()` for `yearweek` and `yearquarter` for non-default week start. (#299)

--- a/R/time-wise.R
+++ b/R/time-wise.R
@@ -43,5 +43,5 @@ difference <- function(x, lag = 1, differences = 1, default = NA,
 
 diff_impl <- function(x, lag = 1, differences = 1, default = NA) {
   diff_x <- diff(x, lag = lag, differences = differences)
-  vec_c(vec_rep(default, lag * differences), diff_x)
+  vec_c(vec_rep(default, pmin(vec_size(x), lag * differences)), diff_x)
 }

--- a/tests/testthat/test-timewise.R
+++ b/tests/testthat/test-timewise.R
@@ -21,3 +21,8 @@ test_that("difference() with `order_by`", {
   #   right <- mutate(scrambled, diff = difference(value, order_by = year)), msg)
   # expect_equal(sort(right$diff, na.last = FALSE), difference(tsbl$value))
 })
+
+
+test_that("difference() with short time series (#310)", {
+  expect_length(difference(1, differences = 3), 1L)
+})


### PR DESCRIPTION
``` r
library(tsibble)
#> 
#> Attaching package: 'tsibble'
#> The following objects are masked from 'package:base':
#> 
#>     intersect, setdiff, union
difference(1, differences = 3)
#> [1] NA
```

<sup>Created on 2024-05-12 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>

Resolves #310